### PR TITLE
Dynamic Fits Reporting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pandorafits"
-version = "0.4.8"
+version = "0.5.0"
 description = "Tools to work with fits files for Pandora"
 authors = ["Christina Hedges <christina.l.hedges@nasa.gov>"]
 license = "MIT"

--- a/src/pandorafits/nirda.py
+++ b/src/pandorafits/nirda.py
@@ -2,6 +2,7 @@
 import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 from astropy.coordinates import SkyCoord
 
 from . import FORMATSDIR, NIRDAReference, logger
@@ -122,10 +123,50 @@ class NIRDALevel0HDUList(PandoraHDUList, ReportMixins):
         # ax.margins(0)
         return ax
 
+    def describe(self):
+        keys = [
+            "TARG_ID",
+            "TARG_RA",
+            "TARG_DEC",
+            "EXPOSRES",
+            "RESETS1",
+            "RESETS2",
+            "DROPS1",
+            "DROPS2",
+            "DROPS3",
+            "READS",
+            "GRPS",
+            "INTEGRTS",
+            "ROISIZEX",
+            "ROISIZEY",
+            "TCLDTIP1"
+        ]
+
+        hdr = self[0].header
+        rows = []
+        for key in keys:
+            try:
+                value = hdr[key]
+                comment = hdr.comments[key]
+            except (KeyError, IndexError):
+                value, comment = "N/A", ""
+            if key in ("TARG_RA", "TARG_DEC", "TCLDTIP1"):
+                try:
+                    value = round(float(value), 4)
+                except (TypeError, ValueError):
+                    pass
+            rows.append([key, value, comment])
+
+        df = pd.DataFrame(
+            rows, columns=["Key", "Value", "Comment"]
+        ).set_index("Key")
+        return df
+
     def get_report_materials(self):
         report_materials = dict()
         report_materials['title'] = self[0].header.get("targ_id", "UNKNOWN")
         report_materials['subtitle'] = self.start_time.isot
+        report_materials['report_metrics'] = self.describe()
         report_materials['report_plots'] = [
             lambda ax=None: self.plot_data(ax=ax)
         ]

--- a/src/pandorafits/nirda.py
+++ b/src/pandorafits/nirda.py
@@ -139,7 +139,7 @@ class NIRDALevel0HDUList(PandoraHDUList, ReportMixins):
             "INTEGRTS",
             "ROISIZEX",
             "ROISIZEY",
-            "TCLDTIP1"
+            "TCLDTIP1",
         ]
 
         hdr = self[0].header
@@ -157,17 +157,17 @@ class NIRDALevel0HDUList(PandoraHDUList, ReportMixins):
                     pass
             rows.append([key, value, comment])
 
-        df = pd.DataFrame(
-            rows, columns=["Key", "Value", "Comment"]
-        ).set_index("Key")
+        df = pd.DataFrame(rows, columns=["Key", "Value", "Comment"]).set_index(
+            "Key"
+        )
         return df
 
     def get_report_materials(self):
         report_materials = dict()
-        report_materials['title'] = self[0].header.get("targ_id", "UNKNOWN")
-        report_materials['subtitle'] = self.start_time.isot
-        report_materials['report_metrics'] = self.describe()
-        report_materials['report_plots'] = [
+        report_materials["title"] = self[0].header.get("targ_id", "UNKNOWN")
+        report_materials["subtitle"] = self.start_time.isot
+        report_materials["report_metrics"] = self.describe()
+        report_materials["report_plots"] = [
             lambda ax=None: self.plot_data(ax=ax)
         ]
 

--- a/src/pandorafits/nirda.py
+++ b/src/pandorafits/nirda.py
@@ -7,6 +7,7 @@ from astropy.coordinates import SkyCoord
 from . import FORMATSDIR, NIRDAReference, logger
 from .fits import PandoraHDUList
 from .io import register_hdulist
+from .report import ReportMixins
 from .scene import get_NIRDA_scene
 from .utils import convert_time
 
@@ -89,7 +90,7 @@ def get_nirda_exposure_times(hdr):
         )
     )
 )
-class NIRDALevel0HDUList(PandoraHDUList):
+class NIRDALevel0HDUList(PandoraHDUList, ReportMixins):
     filename = FORMATSDIR + "nirda/level0_nirda.xlsx"
     reference = NIRDAReference
     level = 0
@@ -99,6 +100,7 @@ class NIRDALevel0HDUList(PandoraHDUList):
         return NIRDALevel1HDUList(self)
 
     def plot_data(self, ax=None, **kwargs):
+        ax_provided = ax is not None
         if ax is None:
             _, ax = plt.subplots()
         d = self["science"].data[0]
@@ -110,13 +112,25 @@ class NIRDALevel0HDUList(PandoraHDUList):
         )
         ax.set(
             aspect="equal",
-            title=f"{self[0].header['targ_id']} {self.start_time.isot}",
             xlabel="ROI Column",
             ylabel="ROI Row",
         )
+        if not ax_provided:
+            # Don't add titles for figures made for fits reports.
+            ax.set(title=f"{self[0].header['targ_id']} {self.start_time.isot}")
         plt.colorbar(im, ax=ax)
         # ax.margins(0)
         return ax
+
+    def get_report_materials(self):
+        report_materials = dict()
+        report_materials['title'] = self[0].header.get("targ_id", "UNKNOWN")
+        report_materials['subtitle'] = self.start_time.isot
+        report_materials['report_plots'] = [
+            lambda ax=None: self.plot_data(ax=ax)
+        ]
+
+        return report_materials
 
 
 @register_hdulist(

--- a/src/pandorafits/report.py
+++ b/src/pandorafits/report.py
@@ -33,23 +33,29 @@ def plot_table(ax, df):
 
 
 class ReportMixins:
-    
+
     def get_report_materials(self, *args, **kwargs):
-        """Details that make up a report. This is overridden by sub classes. """
+        """Details that make up a report. This is overridden by sub classes."""
         return dict()
 
-    def build_report_figure(self, *, dpi: int = 150, wspace: float = 1.3, hspace: float = 0.2):
+    def build_report_figure(
+        self, *, dpi: int = 150, wspace: float = 1.3, hspace: float = 0.2
+    ):
         """
         6-row x 6-col GridSpec report. figsize (12, 10) gives equal 2-inch squares.
         """
         fig = plt.figure(figsize=(12, 10), dpi=dpi, constrained_layout=True)
-        gs  = fig.add_gridspec(6, 6, wspace=wspace, hspace=hspace)
+        gs = fig.add_gridspec(6, 6, wspace=wspace, hspace=hspace)
 
         # Create figure axes. Could do this programmatically but want finer control because they
         # are not all the same size/shape.
         report_plot_axes = list()
-        report_plot_axes.append(fig.add_subplot(gs[0:2, 0:3]))  # Index 0 is reserved for table-based metrics.
-        report_plot_axes.append(fig.add_subplot(gs[0:2, 3:6]))  # Index 1 is reserved for table-based metrics.
+        report_plot_axes.append(
+            fig.add_subplot(gs[0:2, 0:3])
+        )  # Index 0 is reserved for table-based metrics.
+        report_plot_axes.append(
+            fig.add_subplot(gs[0:2, 3:6])
+        )  # Index 1 is reserved for table-based metrics.
         report_plot_axes.append(fig.add_subplot(gs[2:4, 0:2]))
         report_plot_axes.append(fig.add_subplot(gs[2:4, 2:4]))
         report_plot_axes.append(fig.add_subplot(gs[2:4, 4:6]))
@@ -81,8 +87,15 @@ class ReportMixins:
             if subtitle != "":
                 # Just put the subtitle on the same line.
                 title_use += f" :: {subtitle}"
-            fig.text(x0, y, title_use, ha="left", va="top",
-                     fontsize=title_fs, fontweight="bold")
+            fig.text(
+                x0,
+                y,
+                title_use,
+                ha="left",
+                va="top",
+                fontsize=title_fs,
+                fontweight="bold",
+            )
 
         # Metrics about the observation as a whole.
         report_metrics = materials.get("report_metrics", None)
@@ -97,7 +110,7 @@ class ReportMixins:
         # Plots that are generally timeseries of one or metrics
         report_plot_funcs = materials.get("report_plots", [])
         for fig_index, ax in enumerate(report_plot_axes[2:]):
-            
+
             # Plot to this axis if there is a function to plot at this location.
             if fig_index < len(report_plot_funcs):
                 plot_func = report_plot_funcs[fig_index]

--- a/src/pandorafits/report.py
+++ b/src/pandorafits/report.py
@@ -5,146 +5,123 @@ from __future__ import annotations
 
 # Third-party
 import matplotlib.pyplot as plt
-import pandas as pd
 from matplotlib.backends.backend_pdf import PdfPages
 
 
+def plot_table(ax, df):
+    """Render a compact DataFrame table sized to the content."""
+    ax.axis("off")
+    if df.empty:
+        return
+    df_str = df.astype(str)
+    table = ax.table(
+        cellText=df_str.values,
+        rowLabels=list(df_str.index),
+        colLabels=list(df_str.columns),
+        loc="upper left",
+        cellLoc="left",
+    )
+    table.auto_set_font_size(False)
+    table.set_fontsize(9)
+    # Size every column to fit its widest cell (axes-fraction coords)
+    table.auto_set_column_width([-1, 0, 1])
+    for (row, col), cell in table.get_celld().items():
+        cell.PAD = 0.015
+        if row == 0 or col == -1:
+            cell.set_text_props(weight="bold")
+    table.scale(1.0, 1.1)
+
+
 class ReportMixins:
-    def plot_description(self, ax=None):
-        if ax is None:
-            _, ax = plt.subplots()
+    
+    def get_report_materials(self, *args, **kwargs):
+        """Details that make up a report. This is overridden by sub classes. """
+        return dict()
 
-        ax.axis("off")
-        df = self.describe().astype(str)
-
-        # Draw table constrained to axes bbox
-        table = pd.plotting.table(
-            ax,
-            df,
-            loc="upper left",
-            cellLoc="left",
-            colLoc="left",
-            bbox=[0.1, 0.1, 0.95, 0.95],  # FORCE table into axes
-        )
-
-        table.auto_set_font_size(False)
-        table.set_fontsize(10)
-
-        # Column width control (relative to axes)
-        widths = {
-            -1: 0.18,  # index
-            0: 0.22,  # key
-            1: 0.60,  # value / comment
-        }
-
-        for (row, col), cell in table.get_celld().items():
-            if col in widths:
-                cell.set_width(widths[col])
-            cell.PAD = 0.02
-
-            # Bold header + index
-            if row == 0 or col == -1:
-                cell.set_text_props(weight="bold")
-
-        # Final vertical compaction
-        table.scale(1.0, 0.9)
-
-        return ax
-
-    def _build_report_figure_letter_3x2(self, *, dpi: int = 150):
+    def build_report_figure(self, *, dpi: int = 150, wspace: float = 1.3, hspace: float = 0.2):
         """
-        Build a SINGLE letter-size figure laid out as a 3x2 grid.
-        Materials are drawn into provided axes (preferred). If a material
-        returns an Axes from its own figure, we embed that figure as an image.
+        6-row x 6-col GridSpec report. figsize (12, 10) gives equal 2-inch squares.
         """
-        materials = list(self.get_report_materials())
+        fig = plt.figure(figsize=(12, 10), dpi=dpi, constrained_layout=True)
+        gs  = fig.add_gridspec(6, 6, wspace=wspace, hspace=hspace)
 
-        # Letter size: 8.5 x 11 inches
-        fig, axes = plt.subplots(
-            nrows=2,
-            ncols=3,
-            figsize=(11, 8.5),  # LETTER LANDSCAPE
-            constrained_layout=True,
-            dpi=dpi,
-        )
-        axes = axes.ravel()
+        # Create figure axes. Could do this programmatically but want finer control because they
+        # are not all the same size/shape.
+        report_plot_axes = list()
+        report_plot_axes.append(fig.add_subplot(gs[0:2, 0:3]))  # Index 0 is reserved for table-based metrics.
+        report_plot_axes.append(fig.add_subplot(gs[0:2, 3:6]))  # Index 1 is reserved for table-based metrics.
+        report_plot_axes.append(fig.add_subplot(gs[2:4, 0:2]))
+        report_plot_axes.append(fig.add_subplot(gs[2:4, 2:4]))
+        report_plot_axes.append(fig.add_subplot(gs[2:4, 4:6]))
+        report_plot_axes.append(fig.add_subplot(gs[4:6, 0:2]))
+        report_plot_axes.append(fig.add_subplot(gs[4:6, 2:4]))
+        report_plot_axes.append(fig.add_subplot(gs[4:6, 4:6]))
 
-        def _embed_axes_or_figure(target_ax, obj):
-            """Render an existing Axes/Figure onto target_ax as an image."""
-            target_ax.axis("off")
-            if isinstance(obj, plt.Axes):
-                src_fig = obj.figure
-            elif isinstance(obj, plt.Figure):
-                src_fig = obj
-            else:
-                raise TypeError(f"Expected Axes/Figure, got {type(obj)!r}")
+        # Overridden by sub classes
+        materials = self.get_report_materials()
+        if materials is None:
+            # Probably being called by the wrong class. Break early.
+            return fig
+        if len(materials) == 0:
+            return fig
 
-            # draw + pull RGBA buffer (no disk)
-            src_fig.canvas.draw()
-            w, h = src_fig.canvas.get_width_height()
-            # Third-party
-            import numpy as np
+        # Basic information about the target and observation time
+        title = materials.get("title", "")
+        subtitle = materials.get("subtitle", "")
+        if title:
+            # Shrink the gridspec rect to leave a strip at the top for the title
+            fig_layout_engine = fig.get_layout_engine()
+            if fig_layout_engine is not None:
+                fig_layout_engine.set(rect=[0, 0, 1, 0.93])
+            x0, y = 0.04, 0.975
+            title_fs = 16
+            title_use = ""
+            if title != "":
+                title_use += title
+            if subtitle != "":
+                # Just put the subtitle on the same line.
+                title_use += f" :: {subtitle}"
+            fig.text(x0, y, title_use, ha="left", va="top",
+                     fontsize=title_fs, fontweight="bold")
 
-            rgba = np.frombuffer(
-                src_fig.canvas.buffer_rgba(), dtype=np.uint8
-            ).reshape(h, w, 4)
-            target_ax.imshow(rgba)
+        # Metrics about the observation as a whole.
+        report_metrics = materials.get("report_metrics", None)
+        if report_metrics is not None and not report_metrics.empty:
+            mid = (len(report_metrics) + 1) // 2
+            plot_table(report_plot_axes[0], report_metrics.iloc[:mid])
+            plot_table(report_plot_axes[1], report_metrics.iloc[mid:])
+        else:
+            report_plot_axes[0].axis("off")
+            report_plot_axes[1].axis("off")
 
-        # Fill grid left-to-right, top-to-bottom
-        for i, ax in enumerate(axes):
-            if i >= len(materials):
-                ax.axis("off")
-                continue
-            if materials[i] is None:
-                ax.axis("off")
-                continue
-
-            item = materials[i]
-
-            # Preferred path: if item is callable that can draw into ax
-            if callable(item):
-                try:
-                    out = item(ax=ax)
-                except TypeError:
-                    out = item()
-                if out is None:
+        # Plots that are generally timeseries of one or metrics
+        report_plot_funcs = materials.get("report_plots", [])
+        for fig_index, ax in enumerate(report_plot_axes[2:]):
+            
+            # Plot to this axis if there is a function to plot at this location.
+            if fig_index < len(report_plot_funcs):
+                plot_func = report_plot_funcs[fig_index]
+                if plot_func is not None:
+                    plot_func(ax=ax)
                     continue
-                item = out
-
-            # If item is Axes/Figure made elsewhere, embed it
-            if isinstance(item, (plt.Axes, plt.Figure)):
-                # If it's an Axes on THIS fig already, nothing to do
-                if isinstance(item, plt.Axes) and item.figure is fig:
-                    continue
-                _embed_axes_or_figure(ax, item)
-                continue
-
-            # If it's something else, user should convert it to a plot method
-            raise TypeError(
-                f"Unsupported report material type: {type(item)!r}"
-            )
+            # Otherwise turn the axis off.
+            ax.axis("off")
 
         return fig
 
     def make_report(self, *, force: bool = False):
-        """
-        Create and cache a single-page report figure.
-        """
+        """Create and cache the report figure."""
         if not force and getattr(self, "_report_fig", None) is not None:
             return self._report_fig
-        self._report_fig = self._build_report_figure_letter_3x2()
+        self._report_fig = self.build_report_figure()
         return self._report_fig
 
     def get_report(self, *, force: bool = False):
-        """
-        Show the single-page report in an interactive session (e.g., Jupyter).
-        """
+        """Show the report in an interactive session (e.g. Jupyter)."""
         return self.make_report(force=force)
 
     def save_report(self, path: str, *, force: bool = False):
-        """
-        Save the single-page report to a PDF.
-        """
+        """Save the report to a PDF."""
         fig = self.make_report(force=force)
         with PdfPages(path) as pdf:
             pdf.savefig(fig)

--- a/src/pandorafits/visda.py
+++ b/src/pandorafits/visda.py
@@ -180,6 +180,7 @@ class VISDALevel0HDUList(ReportMixins, PandoraHDUList):
         return mask
 
     def plot_data(self, ax=None, **kwargs):
+        ax_provided = ax is not None
         if ax is None:
             _, ax = plt.subplots()
         d = self["science"].data[0]
@@ -192,6 +193,9 @@ class VISDALevel0HDUList(ReportMixins, PandoraHDUList):
             xlabel="Panel Column",
             ylabel="Panel Row",
         )
+        if not ax_provided:
+            # Don't add titles for figures made for fits reports.
+            ax.set(title=f"{self[0].header['targ_id']} {self.start_time.isot}")
         plt.colorbar(im, ax=ax)
         # ax.margins(0)
         return ax
@@ -309,6 +313,7 @@ class VISDALevel0HDUList(ReportMixins, PandoraHDUList):
         return df
 
     def plot_astrometry(self, ax=None, **kwargs):
+        ax_provided = ax is not None
         if ax is None:
             _, ax = plt.subplots()
         df = self.get_position_data()
@@ -327,6 +332,9 @@ class VISDALevel0HDUList(ReportMixins, PandoraHDUList):
             xlabel="Time in Exposure [s]",
             ylabel="Position - Mean Position [arcsecond]",
         )
+        if not ax_provided:
+            # Don't add titles for figures made for fits reports.
+            ax.set(title=f"{self[0].header['targ_id']} {self.start_time.isot}")
         return ax
 
     def describe(self):
@@ -509,6 +517,7 @@ class VISDAFFILevel0HDUList(ReportMixins, PandoraHDUList):
     instrument = "VISDA"
 
     def plot_data(self, ax=None, **kwargs):
+        ax_provided = ax is not None
         if ax is None:
             _, ax = plt.subplots()
         d = self["science"].data[0]
@@ -521,6 +530,9 @@ class VISDAFFILevel0HDUList(ReportMixins, PandoraHDUList):
             xlabel="Column",
             ylabel="Row",
         )
+        if not ax_provided:
+            # Don't add titles for figures made for fits reports.
+            ax.set(title=f"{self[0].header['targ_id']} {self.start_time.isot}")
         plt.colorbar(im, ax=ax)
         # ax.margins(0)
         return ax

--- a/src/pandorafits/visda.py
+++ b/src/pandorafits/visda.py
@@ -339,22 +339,35 @@ class VISDALevel0HDUList(ReportMixins, PandoraHDUList):
 
     def describe(self):
         keys = [
-            "NUMSTARS",
             "TARG_ID",
             "TARG_RA",
             "TARG_DEC",
+            "NUMSTARS",
             "FRMSREQD",
             "FRMSCLCT",
-            "NUMSTARS",
             "STARDIMS",
             "NUMPCOAD",
             "FRMPCOAD",
+            "TARG_RLL",
         ]
 
         hdr = self[0].header
+        rows = []
+        for key in keys:
+            try:
+                value = hdr[key]
+                comment = hdr.comments[key]
+            except (KeyError, IndexError):
+                value, comment = "N/A", ""
+            if key in ("TARG_RA", "TARG_DEC"):
+                try:
+                    value = round(float(value), 4)
+                except (TypeError, ValueError):
+                    pass
+            rows.append([key, value, comment])
+
         df = pd.DataFrame(
-            np.asarray([hdr.cards[key] for key in keys]),
-            columns=["Key", "Value", "Comment"],
+            rows, columns=["Key", "Value", "Comment"]
         ).set_index("Key")
         return df
 
@@ -540,12 +553,34 @@ class VISDAFFILevel0HDUList(ReportMixins, PandoraHDUList):
     def describe(self):
         keys = [
             "TARG_ID",
+            "TARG_RA",
+            "TARG_DEC",
+            "NUMSTARS",
+            "FRMSREQD",
+            "FRMSCLCT",
+            "STARDIMS",
+            "NUMPCOAD",
+            "FRMPCOAD",
+            "TARG_RLL",
         ]
 
         hdr = self[0].header
+        rows = []
+        for key in keys:
+            try:
+                value = hdr[key]
+                comment = hdr.comments[key]
+            except (KeyError, IndexError):
+                value, comment = "N/A", ""
+            if key in ("TARG_RA", "TARG_DEC"):
+                try:
+                    value = round(float(value), 4)
+                except (TypeError, ValueError):
+                    pass
+            rows.append([key, value, comment])
+
         df = pd.DataFrame(
-            np.asarray([hdr.cards[key] for key in keys]),
-            columns=["Key", "Value", "Comment"],
+            rows, columns=["Key", "Value", "Comment"]
         ).set_index("Key")
         return df
 

--- a/src/pandorafits/visda.py
+++ b/src/pandorafits/visda.py
@@ -366,19 +366,19 @@ class VISDALevel0HDUList(ReportMixins, PandoraHDUList):
                     pass
             rows.append([key, value, comment])
 
-        df = pd.DataFrame(
-            rows, columns=["Key", "Value", "Comment"]
-        ).set_index("Key")
+        df = pd.DataFrame(rows, columns=["Key", "Value", "Comment"]).set_index(
+            "Key"
+        )
         return df
 
     def get_report_materials(self):
         report_materials = dict()
-        report_materials['title'] = self[0].header.get("targ_id", "UNKNOWN")
-        report_materials['subtitle'] = self.start_time.isot
-        report_materials['report_metrics'] = self.describe()
-        report_materials['report_plots'] = [
+        report_materials["title"] = self[0].header.get("targ_id", "UNKNOWN")
+        report_materials["subtitle"] = self.start_time.isot
+        report_materials["report_metrics"] = self.describe()
+        report_materials["report_plots"] = [
             lambda ax=None: self.plot_data(ax=ax),
-            lambda ax=None: self.plot_astrometry(ax=ax)
+            lambda ax=None: self.plot_astrometry(ax=ax),
         ]
 
         return report_materials
@@ -579,17 +579,17 @@ class VISDAFFILevel0HDUList(ReportMixins, PandoraHDUList):
                     pass
             rows.append([key, value, comment])
 
-        df = pd.DataFrame(
-            rows, columns=["Key", "Value", "Comment"]
-        ).set_index("Key")
+        df = pd.DataFrame(rows, columns=["Key", "Value", "Comment"]).set_index(
+            "Key"
+        )
         return df
 
     def get_report_materials(self):
         report_materials = dict()
-        report_materials['title'] = self[0].header.get("targ_id", "UNKNOWN")
-        report_materials['subtitle'] = self.start_time.isot
-        report_materials['report_metrics'] = self.describe()
-        report_materials['report_plots'] = [
+        report_materials["title"] = self[0].header.get("targ_id", "UNKNOWN")
+        report_materials["subtitle"] = self.start_time.isot
+        report_materials["report_metrics"] = self.describe()
+        report_materials["report_plots"] = [
             lambda ax=None: self.plot_data(ax=ax)
         ]
 

--- a/src/pandorafits/visda.py
+++ b/src/pandorafits/visda.py
@@ -189,7 +189,6 @@ class VISDALevel0HDUList(ReportMixins, PandoraHDUList):
         im = ax.pcolormesh(d, vmin=vmin, vmax=vmax, **kwargs)
         ax.set(
             aspect="equal",
-            title=f"{self[0].header['targ_id']} {self.start_time.isot}",
             xlabel="Panel Column",
             ylabel="Panel Row",
         )
@@ -325,7 +324,6 @@ class VISDALevel0HDUList(ReportMixins, PandoraHDUList):
         )
         ax.legend()
         ax.set(
-            title=f"{self[0].header['targ_id']} {self.start_time.isot}",
             xlabel="Time in Exposure [s]",
             ylabel="Position - Mean Position [arcsecond]",
         )
@@ -353,12 +351,16 @@ class VISDALevel0HDUList(ReportMixins, PandoraHDUList):
         return df
 
     def get_report_materials(self):
-        return [
+        report_materials = dict()
+        report_materials['title'] = self[0].header.get("targ_id", "UNKNOWN")
+        report_materials['subtitle'] = self.start_time.isot
+        report_materials['report_metrics'] = self.describe()
+        report_materials['report_plots'] = [
             lambda ax=None: self.plot_data(ax=ax),
-            lambda ax=None: self.plot_astrometry(ax=ax),
-            None,
-            lambda ax=None: self.plot_description(ax=ax),
+            lambda ax=None: self.plot_astrometry(ax=ax)
         ]
+
+        return report_materials
 
     def get_earth_angle(self):
         return ps.get_angle_to_body(
@@ -516,7 +518,6 @@ class VISDAFFILevel0HDUList(ReportMixins, PandoraHDUList):
         im = ax.pcolormesh(d, vmin=vmin, vmax=vmax, **kwargs)
         ax.set(
             aspect="equal",
-            title=f"{self[0].header['targ_id']} {self.start_time.isot}",
             xlabel="Column",
             ylabel="Row",
         )
@@ -537,12 +538,15 @@ class VISDAFFILevel0HDUList(ReportMixins, PandoraHDUList):
         return df
 
     def get_report_materials(self):
-        return [
-            lambda ax=None: self.plot_data(ax=ax),
-            None,
-            None,
-            lambda ax=None: self.plot_description(ax=ax),
+        report_materials = dict()
+        report_materials['title'] = self[0].header.get("targ_id", "UNKNOWN")
+        report_materials['subtitle'] = self.start_time.isot
+        report_materials['report_metrics'] = self.describe()
+        report_materials['report_plots'] = [
+            lambda ax=None: self.plot_data(ax=ax)
         ]
+
+        return report_materials
 
     def __to_l1__(self):
         return VISDAFFILevel1HDUList(self)


### PR DESCRIPTION
Adds more dynamic fits file reporting for both level 0 NIRDA and VISDA data. Also expands which metrics are reported for each via `self.describe()`. 

How to generate reports:
```
import pandorafits as pf
vis_fpath = "some\path\to\vis.fits"
vis_l0 = pf.open(vis_fpath)
vis_l0.describe()
vis_l0.get_report()
vis_l0.save_report('vis.pdf')
```